### PR TITLE
Fix the name of file which would be set executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ If using Docker
 
 ```
 cd airflow-101/mwaa-local-runner
-chmod +x mwaa-local-runner
+chmod +x mwaa-local-env
 ./mwaa-local-env
 
 ```


### PR DESCRIPTION
I think it might be a wrong name 'mwaa-local-runner' of file to be set executable on line 209, as that it will run another file ’mwaa-local-env‘.